### PR TITLE
00019 replace rm calls with rmtree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ test: ALWAYS
 	@make local
 	pytest -v ./tests/poof-test.py
 	pytest -v ./tests/launchd-test.py
+	pytest -v ./tests/nukedir-test.py
 	pip uninstall -y $(PACKAGE)==$(VERSION) || true
 	rm -Rfv $$(find $(PACKAGE)/ | awk '/__pycache__$$/')
 	rm -Rfv $$(find tests | awk '/__pycache__$$/')

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-% poof(1) Version 1.3.7 | Secure cloud storage backup documentation
+% poof(1) Version 1.4.0 | Secure cloud storage backup documentation
 
 
 Name

--- a/poof/__init__.py
+++ b/poof/__init__.py
@@ -293,9 +293,11 @@ def _clone(toCloud, confDir = POOF_CONFIG_DIR, confFiles = POOF_CONFIG_FILES, nu
             continue
 
         if toCloud and 'poof' not in localDir and nukeLocal:
-            status, error = nukeDirectory(localDir)
-            if not status:
+            errorsList = nukeDirectory(localDir)
+            if errorsList:
                 click.secho('  > dir %s may be system-protected' % localDir, fg = 'bright_cyan')
+                for error in errorsList:
+                    click.secho(' > %s' % error, fg = 'bright_cyan')
         elif nukeLocal:
             poofDir = localDir
 

--- a/poof/__init__.py
+++ b/poof/__init__.py
@@ -12,6 +12,7 @@ from poof.launchd import LAUNCH_AGENT_FULL_PATH
 from poof.launchd import TEST_LAUNCH_AGENT_FULL_PATH
 from poof.launchd import TEST_LAUNCH_AGENT_POOF
 from poof.launchd import TEST_LAUNCH_AGENT_PROG
+from poof.nukedir import nukeDirectory
 
 
 import configparser
@@ -33,7 +34,7 @@ import poof.launchd as launchd
 
 # *** constants ***
 
-__VERSION__ = "1.3.7"
+__VERSION__ = "1.4.0"
 
 RCLONE_PROG      = '/usr/local/bin/rclone' if sys.platform == 'darwin' else 'rclone'
 RCLONE_PROG_TEST = 'ls' # a program we know MUST exist to the which command
@@ -200,26 +201,6 @@ def _getNukeDirectoryArgsWindows(path):
     raise NotImplementedError
 
 
-def _nukeDirectory(path):
-    result = False
-    error  = Exception()
-    args = False
-
-    hostPlatform = platform.system()
-
-    if os.path.exists(path):
-        if 'Darwin' == hostPlatform:
-            args =  _getNukeDirectoryArgsMac(path)
-        elif 'Linux' == hostPlatform:
-            args =  _getNukeDirectoryArgsLinux(path)
-
-    if args:
-        procResult = subprocess.run(args)
-        result = not procResult.returncode
-
-    return result, error
-
-
 def _config(confFiles = POOF_CONFIG_FILES, confDir = POOF_CONFIG_DIR, showConfig = True):
     confFile = confFiles['poof.conf']
     _initializeConfigIn(confFile, confDir)
@@ -312,7 +293,7 @@ def _clone(toCloud, confDir = POOF_CONFIG_DIR, confFiles = POOF_CONFIG_FILES, nu
             continue
 
         if toCloud and 'poof' not in localDir and nukeLocal:
-            status, error = _nukeDirectory(localDir)
+            status, error = nukeDirectory(localDir)
             if not status:
                 click.secho('  > dir %s may be system-protected' % localDir, fg = 'bright_cyan')
         elif nukeLocal:

--- a/poof/nukedir.py
+++ b/poof/nukedir.py
@@ -6,6 +6,9 @@ import platform
 import subprocess
 
 
+# TODO:  Reference - https://docs.python.org/3/library/shutil.html
+
+
 # TODO:  use the Python API instead of calling external OS-levels commands here?
 #        Neither rm -P nor srm are standard, and neither has much effect on
 #        actual security since they don't work on SSDs anyway.

--- a/poof/nukedir.py
+++ b/poof/nukedir.py
@@ -1,0 +1,58 @@
+# See: https://github.com/poof-backup/poof/blob/master/LICENSE.txt
+
+
+import os
+import platform
+import subprocess
+
+
+# TODO:  use the Python API instead of calling external OS-levels commands here?
+#        Neither rm -P nor srm are standard, and neither has much effect on
+#        actual security since they don't work on SSDs anyway.
+#
+#        https://github.com/poof-backup/poof/issues/59
+def _getNukeDirectoryArgsMac(path):
+	args = (
+		'/bin/rm',
+		'-Prf',
+		path,
+	)
+	return args
+
+
+def _getNukeDirectoryArgsLinux(path):
+	args = (
+		'/bin/rm',
+		'-Rf',
+		path,
+	)
+	return args
+
+
+def _getNukeDirectoryArgsWindows(path):
+    raise NotImplementedError
+
+
+def nukeDirectoryProcess(path):
+    result = False
+    error  = Exception()
+    args = False
+
+    hostPlatform = platform.system()
+
+    if os.path.exists(path):
+        if 'Darwin' == hostPlatform:
+            args =  _getNukeDirectoryArgsMac(path)
+        elif 'Linux' == hostPlatform:
+            args =  _getNukeDirectoryArgsLinux(path)
+
+    if args:
+        procResult = subprocess.run(args)
+        result = not procResult.returncode
+
+    return result, error
+
+
+def nukeDirectory(path):
+    return nukeDirectoryProcess(path)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,13 +34,13 @@ requires-python = '>=3.7'
 
 
 [project.scripts]
-poof = "poof:main"
+poof = 'poof:main'
 
 
 [tool.pytest.ini_options]
-addopts = "-sv"
+addopts = '-sv'
 testpaths = [
-    "tests"
+    'tests'
 ]
 
 
@@ -48,7 +48,7 @@ testpaths = [
 include-package-data = true
 packages = [
     'poof',
-    # "tests", # because test modules import objects from other test modules
+    # 'tests', # because test modules import objects from other test modules
 ]
 
 

--- a/tests/nukedir-test.py
+++ b/tests/nukedir-test.py
@@ -1,0 +1,57 @@
+# See: https://github.com/poof-backup/poof/blob/master/LICENSE.txt
+
+
+from poof.nukedir import _getNukeDirectoryArgsLinux
+from poof.nukedir import _getNukeDirectoryArgsMac
+from poof.nukedir import _getNukeDirectoryArgsWindows
+from poof.nukedir import nukeDirectory
+from poof.nukedir import nukeDirectoryProcess
+
+import os
+import pytest
+
+
+TEST_POOF_CONF_DIR   = './tests/config'
+
+
+def test__getNukeDirectoryArgsMac():
+    path = '/tmp/bogus'
+    argsList = _getNukeDirectoryArgsMac(path)
+    assert isinstance(argsList, tuple)
+    assert argsList[1] == '-Prf'
+
+
+def test__getNukeDirectoryArgsLinux():
+    path = '/tmp/bogus'
+    argsList = _getNukeDirectoryArgsLinux(path)
+    assert isinstance(argsList, tuple)
+    assert argsList[1] == '-Rf'
+
+
+def test__getNukeDirectoryArgsWindows():
+    path = '/tmp/bogus'
+    with pytest.raises(NotImplementedError):
+        _getNukeDirectoryArgsWindows(path)
+        pass
+
+
+def test_nukeDirectoryProcess():
+    bogusDir = os.path.join(TEST_POOF_CONF_DIR, 'bogusxxxxx1213')
+    status, error = nukeDirectoryProcess(bogusDir)
+    assert not status
+
+    os.makedirs(bogusDir, exist_ok = True)
+    status, error = nukeDirectoryProcess(bogusDir)
+    assert status
+
+
+# TODO: Fix DRY!  This is only tests scaffolding.
+def test_nukeDirectory():
+    bogusDir = os.path.join(TEST_POOF_CONF_DIR, 'bogusxxxxx1213')
+    status, error = nukeDirectory(bogusDir)
+    assert not status
+
+    os.makedirs(bogusDir, exist_ok = True)
+    status, error = nukeDirectory(bogusDir)
+    assert status
+

--- a/tests/nukedir-test.py
+++ b/tests/nukedir-test.py
@@ -1,11 +1,7 @@
 # See: https://github.com/poof-backup/poof/blob/master/LICENSE.txt
 
 
-from poof.nukedir import _getNukeDirectoryArgsLinux
-from poof.nukedir import _getNukeDirectoryArgsMac
-from poof.nukedir import _getNukeDirectoryArgsWindows
 from poof.nukedir import nukeDirectory
-from poof.nukedir import nukeDirectoryProcess
 
 import os
 import pytest
@@ -14,44 +10,12 @@ import pytest
 TEST_POOF_CONF_DIR   = './tests/config'
 
 
-def test__getNukeDirectoryArgsMac():
-    path = '/tmp/bogus'
-    argsList = _getNukeDirectoryArgsMac(path)
-    assert isinstance(argsList, tuple)
-    assert argsList[1] == '-Prf'
-
-
-def test__getNukeDirectoryArgsLinux():
-    path = '/tmp/bogus'
-    argsList = _getNukeDirectoryArgsLinux(path)
-    assert isinstance(argsList, tuple)
-    assert argsList[1] == '-Rf'
-
-
-def test__getNukeDirectoryArgsWindows():
-    path = '/tmp/bogus'
-    with pytest.raises(NotImplementedError):
-        _getNukeDirectoryArgsWindows(path)
-        pass
-
-
-def test_nukeDirectoryProcess():
-    bogusDir = os.path.join(TEST_POOF_CONF_DIR, 'bogusxxxxx1213')
-    status, error = nukeDirectoryProcess(bogusDir)
-    assert not status
-
-    os.makedirs(bogusDir, exist_ok = True)
-    status, error = nukeDirectoryProcess(bogusDir)
-    assert status
-
-
-# TODO: Fix DRY!  This is only tests scaffolding.
 def test_nukeDirectory():
     bogusDir = os.path.join(TEST_POOF_CONF_DIR, 'bogusxxxxx1213')
-    status, error = nukeDirectory(bogusDir)
-    assert not status
+    errorsList = nukeDirectory(bogusDir)
+    assert len(errorsList)
 
     os.makedirs(bogusDir, exist_ok = True)
-    status, error = nukeDirectory(bogusDir)
-    assert status
+    errorsList = nukeDirectory(bogusDir)
+    assert not len(errorsList)
 

--- a/tests/poof-test.py
+++ b/tests/poof-test.py
@@ -17,11 +17,7 @@ from poof import _cryptoggle
 from poof import _display_launchdStatus
 from poof import _econfig
 from poof import _encryptionIsEnabled
-from poof import _getNukeDirectoryArgsLinux
-from poof import _getNukeDirectoryArgsMac
-from poof import _getNukeDirectoryArgsWindows
 from poof import _neuter
-from poof import _nukeDirectory
 from poof import _timeLapsed
 from poof import _verify
 from poof import _verifyBogusValuesIn
@@ -189,37 +185,6 @@ def test__neuter():
 
 def test_paths():
     assert CliRunner().invoke(paths)
-
-
-def test__getNukeDirectoryArgsMac():
-    path = '/tmp/bogus'
-    argsList = _getNukeDirectoryArgsMac(path)
-    assert isinstance(argsList, tuple)
-    assert argsList[1] == '-Prf'
-
-
-def test__getNukeDirectoryArgsLinux():
-    path = '/tmp/bogus'
-    argsList = _getNukeDirectoryArgsLinux(path)
-    assert isinstance(argsList, tuple)
-    assert argsList[1] == '-Rf'
-
-
-def test__getNukeDirectoryArgsWindows():
-    path = '/tmp/bogus'
-    with pytest.raises(NotImplementedError):
-        _getNukeDirectoryArgsWindows(path)
-        pass
-
-
-def test__nukeDirectory():
-    bogusDir = os.path.join(TEST_POOF_CONF_DIR, 'bogusxxxxx1213')
-    status, error = _nukeDirectory(bogusDir)
-    assert not status
-
-    os.makedirs(bogusDir, exist_ok = True)
-    status, error = _nukeDirectory(bogusDir)
-    assert status
 
 
 def test__econfig():


### PR DESCRIPTION
Implemented using `shutil.rmtree()` because there is no advantage in using `rm` with special parameters. All major operating systems have deprecated the safety features because of how SSDs work. Given encrypted file systems prevalence, the responsibility of scrubbing the data falls on the user encrypting their file system and complicating data recovery. The 1.4.0 implementation offers an advantage as a side-effect: since it calls `unlink()` recursively at the API level, file deletion is 3 orders of magnitude faster than using the process calls to `rm`. Resolves https://github.com/poof-backup/poof/pull/19.